### PR TITLE
OTPL-4344 Include the K8s cluster name in the metric namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,15 @@ Quick tour
 server.register([
     register: require('ot-hapi-statsd'),
     options: {
-        host: 'statsd.localhost', // your statsd host
-        prefix: 'node-app.development.local.', // Prefix
-        port: 8125, //must be a number default 8125
-        debug: true //could be true/false
-        removePath: {
+        host: 'statsd.localhost', // Required. Your statsd host
+        prefix: 'node-app.', // Required. Service name followed by a '.' 
+        port: 8125, // Optional. Must be a number default 8125
+        debug: true // Optional. Could be true/false
+        removePath: { // Optional
           number: 1, // MUST BE INTEGER
-          regex: '/\[[0-9]+\]/' //when to remove part of the path when empty it will on all the routes
-        }
+          regex: '/\[[0-9]+\]/' // When to remove part of the path when empty it will on all the routes
+        },
+        separateClusterName: true // Optional. Defaults false. Determines whether to separate the k8s prefix from the instance. e.g. k8s-cluster.instance1 vs k8s-cluster-instance1
     }
 ])...
 ```

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -1,6 +1,6 @@
 
 
-module.exports = function(grunt) {
+module.exports = function init(grunt) {
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),
     eslint: {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Hapi.js stats plugin",
   "main": "index.js",
   "engines": {
-    "node": ">=4.0"
+    "node": ">=6.0"
   },
   "directories": {
     "test": "test"
@@ -40,6 +40,8 @@
   "devDependencies": {
     "babel-eslint": "^7.1.1",
     "eslint-config-opentable-es5": "^0.5.0",
+    "eslint": "^2.0.0",
+    "eslint-plugin-mocha": "^3.0.0",
     "expect.js": "^0.3.1",
     "grunt": "^1.0.1",
     "grunt-cli": "^1.2.0",

--- a/src/prefixBuilder.js
+++ b/src/prefixBuilder.js
@@ -1,0 +1,34 @@
+function sanitize(input) {
+  let result = input.toString();
+  result = result.replace(new RegExp('\\s+', 'g'), '-');
+  result = result.replace(new RegExp('/', 'g'), '-');
+  result = result.replace(new RegExp('[^a-zA-Z_\\-0-9\\.]', 'g'), '');
+  result = result.replace(new RegExp('_', 'g'), '-');
+  return result.toLowerCase();
+}
+
+function getInstanceNumberPrefix(options, isKubernetes, kubernetesClusterName) {
+  let instanceNumberPrefix = '';
+  if (isKubernetes && isKubernetes === 'true' && kubernetesClusterName && kubernetesClusterName !== '') {
+    if (options && options.separateClusterName) {
+      instanceNumberPrefix = `${kubernetesClusterName}.`;
+    } else {
+      instanceNumberPrefix = `${kubernetesClusterName}-`;
+    }
+  }
+  return instanceNumberPrefix;
+}
+
+function buildMetricsPrefix(options) {
+  const datacenter = process.env.OT_ENV_LOCATION || 'local';
+  const appEnvironment = process.env.OT_ENV_TYPE || 'dev';
+  const instanceNo = process.env.INSTANCE_NO || '1';
+  const isKubernetes = process.env.IS_KUBERNETES;
+  const kubernetesClusterName = process.env.K8S_CLUSTER_NAME;
+  const instanceNumberPrefix = getInstanceNumberPrefix(options, isKubernetes, kubernetesClusterName);
+  const suppliedPrefix = options && options.prefix ? options.prefix : '';
+  const prefix = `${suppliedPrefix}${appEnvironment}.${datacenter}.${instanceNumberPrefix}instance${instanceNo}`;
+  return sanitize(prefix);
+}
+
+module.exports = buildMetricsPrefix;

--- a/test/prefixBuilder.spec.js
+++ b/test/prefixBuilder.spec.js
@@ -1,0 +1,71 @@
+const expect = require('expect.js');
+const prefixBuilder = require('../src/prefixBuilder');
+
+describe('prefixBuilder', function() {
+  beforeEach(function() {
+    delete process.env.OT_ENV_LOCATION;
+    delete process.env.OT_ENV_TYPE;
+    delete process.env.INSTANCE_NO;
+    delete process.env.IS_KUBERNETES;
+    delete process.env.K8S_CLUSTER_NAME;
+  });
+
+  it('should use the defaults when env vars are not set', function() {
+    const prefix = prefixBuilder({});
+    expect(prefix).to.equal('dev.local.instance1');
+  });
+
+  it('should inlude serviceType in the prefix when set in the provided options', function() {
+    const prefix = prefixBuilder({ prefix: 'my-test-service.' });
+    expect(prefix).to.equal('my-test-service.dev.local.instance1');
+  });
+
+  it('should use the k8s cluster name when env.IS_KUBERNETES is "true" and env.K8S_CLUSTER_NAME is not empty', function() {
+    process.env.IS_KUBERNETES = 'true';
+    process.env.K8S_CLUSTER_NAME = 'my-test-cluster';
+    const prefix = prefixBuilder({ prefix: 'my-test-service.' });
+    expect(prefix).to.equal('my-test-service.dev.local.my-test-cluster-instance1');
+  });
+
+  it('should separate the k8s cluster name from the instance when options.separateClusterName is "true"', function() {
+    process.env.IS_KUBERNETES = 'true';
+    process.env.K8S_CLUSTER_NAME = 'my-test-cluster';
+    const prefix = prefixBuilder({ prefix: 'my-test-service.', separateClusterName: true });
+    expect(prefix).to.equal('my-test-service.dev.local.my-test-cluster.instance1');
+  });
+
+  it('should use env.OT_ENV_LOCATION and env.OT_ENV_TYPE when set', function() {
+    process.env.OT_ENV_TYPE = 'prod';
+    process.env.OT_ENV_LOCATION = 'sc';
+    const prefix = prefixBuilder({ prefix: 'my-test-service.' });
+    expect(prefix).to.equal('my-test-service.prod.sc.instance1');
+  });
+
+  it('should replace all whitespaces with dashes in the prefix', function() {
+    process.env.IS_KUBERNETES = 'true';
+    process.env.K8S_CLUSTER_NAME = 'my test cluster';
+    const prefix = prefixBuilder({ prefix: 'my-test-service.' });
+    expect(prefix).to.equal('my-test-service.dev.local.my-test-cluster-instance1');
+  });
+
+  it('should replace all forward slashes with dashes in the prefix', function() {
+    process.env.IS_KUBERNETES = 'true';
+    process.env.K8S_CLUSTER_NAME = 'my/test/cluster';
+    const prefix = prefixBuilder({ prefix: 'my/test/service.' });
+    expect(prefix).to.equal('my-test-service.dev.local.my-test-cluster-instance1');
+  });
+
+  it('should remove non-alphanumeric chars from the prefix. (excludes "-", "_", ".")', function() {
+    process.env.IS_KUBERNETES = 'true';
+    process.env.K8S_CLUSTER_NAME = 'my!@#\$test%^&*()+cluster.test_1';
+    const prefix = prefixBuilder({ prefix: 'my/test/service.' });
+    expect(prefix).to.equal('my-test-service.dev.local.mytestcluster.test-1-instance1');
+  });
+
+  it('should lowercase the prefix', function() {
+    process.env.IS_KUBERNETES = 'true';
+    process.env.K8S_CLUSTER_NAME = 'MY TEST CLUSTER';
+    const prefix = prefixBuilder({ prefix: 'my/test/service.' });
+    expect(prefix).to.equal('my-test-service.dev.local.my-test-cluster-instance1');
+  });
+});


### PR DESCRIPTION
In this PR:
Added logic to pull the env location, env type, instance number and k8s cluster name from environment variables to construct the metrics prefix. Tests inluded.
Added the separateClusterName optional setting.
Updated minimum node engine to >= 6
Added missing dev deps.
Fixed linting errors.
